### PR TITLE
Adding gradient support in chart colors

### DIFF
--- a/src/GoogleChartGenerator/Chart/AbstractChart.php
+++ b/src/GoogleChartGenerator/Chart/AbstractChart.php
@@ -221,6 +221,13 @@ abstract class AbstractChart {
     }
     
     protected function getColorsUrlPart() {
+        
+        //Allow for gradients based on single chart color
+        if (isset($this->options['color'])){ 
+            return $this->options['color'];
+        }
+        
+        //Process data colors
         $colours = array();
         $autoColoursIndex = 0;
         foreach ($this->getData() as $collection) {


### PR DESCRIPTION
Adding 'color' option to chart. This triggers the use of a gradient for the list of colors (from dark to light) as described in docs: http://code.google.com/apis/chart/image/docs/gallery/pie_charts.html#chart_colors

sorry I used 'color' but i see you use british english,  feel free to change.
